### PR TITLE
feat: 다음 추천 AI 엔드포인트 추가

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from fastapi.responses import JSONResponse
 from fastapi.openapi.utils import get_openapi
 from app.routers import roadmap, courses, chat, internal, quiz, note, crawler, metadata
 from app.core.config import settings
+from app.routers import recommendations # 다음 강좌 추천 엔드포인트 추가
 
 logging.basicConfig(
     level=logging.INFO,
@@ -68,3 +69,4 @@ app.include_router(quiz.router, prefix="/internal")
 app.include_router(note.router, prefix="/internal")
 app.include_router(crawler.router, prefix="/internal")
 app.include_router(metadata.router, prefix="/internal")
+app.include_router(recommendations.router, prefix="/internal") # 다음 강좌 추천 엔드포인트 추가

--- a/app/routers/recommendations.py
+++ b/app/routers/recommendations.py
@@ -1,0 +1,43 @@
+import logging
+from fastapi import APIRouter, HTTPException
+from app.schemas.recommendation import RecommendationRequest, RecommendationResponse, RecommendationCourse
+from app.services.rag import search_courses
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+@router.post("/ai/recommendations", response_model=RecommendationResponse)
+async def get_recommendations(request: RecommendationRequest):
+
+    # 1. 카테고리 기반으로 ChromaDB 벡터 유사도 검색
+    try:
+        query = f"{request.courseTitle} 심화 다음단계 응용" # 강좌 제목에 "심화", "다음단계", "응용" 넣어서 다음 추천 검색
+        candidates = search_courses(
+            query=request.courseTitle,  # 카테고리 -> 강좌 제목으로 변경
+            category=None,  # 카테고리 필터 제거, 유사도만으로 검색
+            top_k=request.top_k,
+        )
+        logger.info(f"[추천] courseId={request.courseId} 기준 후보 {len(candidates)}개 검색됨")
+    except Exception as e:
+        logger.error(f"[추천] 벡터 검색 실패: {e}")
+        raise HTTPException(status_code=500, detail={
+            "code": "SEARCH_ERROR",
+            "message": "강좌 검색 중 오류가 발생했습니다.",
+        })
+
+    # 2. 방금 이수한 강좌 본인 제외
+    filtered = [c for c in candidates if c.course_id != request.courseId]
+
+    # 3. 응답 반환
+    return RecommendationResponse(
+        courses=[
+            RecommendationCourse(
+                course_id=c.course_id,
+                title=c.title,
+                institution=c.institution,
+                category=c.category,
+                duration=c.duration,
+            )
+            for c in filtered
+        ]
+    )

--- a/app/schemas/recommendation.py
+++ b/app/schemas/recommendation.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+
+# Spring Boot에서 AI 서버로 보내는 요청
+class RecommendationRequest(BaseModel):
+    courseId: str   # 가장 최근 이수한 강좌 ID (본인 강좌 제외용)
+    courseTitle: str # 가장 최근 이수한 강좌 제목 (벡터 검색 쿼리용)
+    category: str   # 해당 강좌의 카테고리 (벡터 검색 필터)
+    top_k: int = 5  # 추천 강좌 후보 수
+
+# 추천 강좌 1개
+class RecommendationCourse(BaseModel):
+    course_id: str    # 강좌 ID
+    title: str        # 강좌 제목
+    institution: str  # 운영 기관
+    category: str     # 카테고리
+    duration: str     # 수강 기간
+
+# AI 서버 → Spring Boot 응답
+class RecommendationResponse(BaseModel):
+    courses: list[RecommendationCourse]  # 추천 강좌 목록

--- a/requirements.txt
+++ b/requirements.txt
@@ -102,7 +102,6 @@ typing_extensions==4.15.0
 urllib3==2.6.3
 uuid_utils==0.14.1
 uvicorn==0.44.0
-uvloop==0.22.1
 watchfiles==1.1.1
 websocket-client==1.9.0
 websockets==16.0


### PR DESCRIPTION
## 구현 내용

- POST /internal/ai/recommendations 엔드포인트 추가
- 최근 이수한 강좌의 제목 기반으로 ChromaDB 벡터 유사도 검색
- 본인 강좌 제외 후 후보 강좌 목록 반환
- Spring Boot recommendations 엔드포인트와 연동